### PR TITLE
format composite literals more nicely

### DIFF
--- a/format_composite_literals.go
+++ b/format_composite_literals.go
@@ -1,0 +1,72 @@
+package valast
+
+func formatCompositeLiterals(input []rune) []rune {
+	var (
+		inStringLiteral, inRawStringLiteral bool
+		depth                               int
+		breakFields                         bool
+		result                              []rune
+	)
+	for i, r := range input {
+		switch {
+		case inStringLiteral || inRawStringLiteral:
+			// Reading a string literal.
+			switch {
+			case inStringLiteral:
+				if r == '"' && (i == 0 || input[i-1] != '\\') {
+					inStringLiteral = false
+				}
+			case inRawStringLiteral:
+				if r == '`' {
+					inRawStringLiteral = false
+				}
+			}
+			if r == '\n' {
+				depth = 0
+			}
+			result = append(result, r)
+		default:
+			if r == '"' {
+				inStringLiteral = true
+				result = append(result, r)
+				break
+			}
+			if r == '`' {
+				inRawStringLiteral = true
+				result = append(result, r)
+				break
+			}
+			if r == '\n' {
+				depth = 0
+			}
+			if r == ',' && breakFields {
+				result = append(result, r)
+				result = append(result, '\n')
+				break
+			}
+			if r == '{' {
+				depth++
+				if depth >= 2 {
+					depth = 0
+					breakFields = true
+					result = append(result, r)
+					result = append(result, '\n')
+					break
+				}
+			}
+			if r == '}' {
+				depth--
+				if depth >= 2 {
+					depth = 0
+					breakFields = false
+					result = append(result, r)
+					result = append(result, ',')
+					result = append(result, '\n')
+					break
+				}
+			}
+			result = append(result, r)
+		}
+	}
+	return result
+}

--- a/testdata/TestExportedOnly_input__struct_same_package.golden
+++ b/testdata/TestExportedOnly_input__struct_same_package.golden
@@ -1,1 +1,3 @@
-baz{Bam: (1.34 + 0i), zeta: foo{bar: "hello"}}
+baz{Bam: (1.34 + 0i), zeta: foo{
+	bar: "hello",
+}}

--- a/testdata/TestRecursion__basic.golden
+++ b/testdata/TestRecursion__basic.golden
@@ -1,1 +1,10 @@
-&valast.foo{name: "one", bar: &valast.foo{name: "two", bar: &valast.foo{name: "three", bar: &valast.foo{name: "four", bar: &valast.foo{name: "five"}}}}}
+&valast.foo{name: "one", bar: &valast.foo{
+	name: "two",
+	bar: &valast.foo{
+		name: "three",
+		bar: &valast.foo{
+			name: "four",
+			bar:  &valast.foo{name: "five"},
+		},
+	},
+}}

--- a/testdata/TestRecursion__struct_cyclic.golden
+++ b/testdata/TestRecursion__struct_cyclic.golden
@@ -1,1 +1,4 @@
-&valast.foo{name: "one", bar: &valast.foo{name: "one", bar: nil}}
+&valast.foo{name: "one", bar: &valast.foo{
+	name: "one",
+	bar:  nil,
+}}

--- a/testdata/TestString__array.golden
+++ b/testdata/TestString__array.golden
@@ -1,1 +1,6 @@
-[2]*baz{&baz{Beta: "foo"}, &baz{Beta: 123}}
+[2]*baz{
+	&baz{
+		Beta: "foo",
+	},
+	&baz{Beta: 123},
+}

--- a/testdata/TestString__interface.golden
+++ b/testdata/TestString__interface.golden
@@ -1,3 +1,5 @@
 &struct {
 	v test.Bazer
-}{v: &test.Baz{Bam: (1.34 + 0i), zeta: &test.foo{bar: "hello"}}}
+}{v: &test.Baz{Bam: (1.34 + 0i), zeta: &test.foo{
+	bar: "hello",
+}}}

--- a/testdata/TestString__interface_anonymous.golden
+++ b/testdata/TestString__interface_anonymous.golden
@@ -3,4 +3,6 @@
 		Baz() error
 		String() string
 	}
-}{v: &test.Baz{Bam: (1.34 + 0i), zeta: &test.foo{bar: "hello"}}}
+}{v: &test.Baz{Bam: (1.34 + 0i), zeta: &test.foo{
+	bar: "hello",
+}}}

--- a/testdata/TestString__slice.golden
+++ b/testdata/TestString__slice.golden
@@ -1,1 +1,7 @@
-[]*baz{&baz{Beta: "foo"}, &baz{Beta: 123}, &baz{Beta: 3}}
+[]*baz{
+	&baz{
+		Beta: "foo",
+	},
+	&baz{Beta: 123},
+	&baz{Beta: 3},
+}

--- a/testdata/TestString__struct_external_package.golden
+++ b/testdata/TestString__struct_external_package.golden
@@ -1,1 +1,3 @@
-&test.Baz{Bam: (1.34 + 0i), zeta: &test.foo{bar: "hello"}}
+&test.Baz{Bam: (1.34 + 0i), zeta: &test.foo{
+	bar: "hello",
+}}

--- a/testdata/TestString__struct_same_package.golden
+++ b/testdata/TestString__struct_same_package.golden
@@ -1,1 +1,3 @@
-baz{Bam: (1.34 + 0i), zeta: foo{bar: "hello"}}
+baz{Bam: (1.34 + 0i), zeta: foo{
+	bar: "hello",
+}}

--- a/valast.go
+++ b/valast.go
@@ -115,6 +115,10 @@ func gofumptFormatExpr(w io.Writer, fset *token.FileSet, expr ast.Expr, opt gofu
 		return err
 	}
 
+	// HACK: Split composite literals onto multiple lines to avoid extra long struct values. We
+	// will defer this to gofumpt once it can perform this: https://github.com/mvdan/gofumpt/pull/70
+	tmpString := string(formatCompositeLiterals([]rune(tmp.String())))
+
 	// Create a temporary file with our expression, run gofumpt on it, and extract the result.
 	fileStart := `package main
 
@@ -123,7 +127,7 @@ func main() {
 	fileEnd := `
 }
 `
-	tmpFile := []byte(fileStart + tmp.String() + fileEnd)
+	tmpFile := []byte(fileStart + tmpString + fileEnd)
 	formattedFile, err := gofumpt.Source(tmpFile, opt)
 	if err != nil {
 		return err


### PR DESCRIPTION
This is a hack (but a quite functional one) to split composite literals
across multiple lines to avoid extra long struct values - which are a
major problem with Valast today and e.g. block me from releasing the
[autogold](https://github.com/hexops/autogold) package.

We will defer this to gofumpt [once it can perform this functionality.](https://github.com/mvdan/gofumpt/pull/70)

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>