### PR TITLE
Add benchmark for ocmplex types

### DIFF
--- a/internal/test/complex_recursive.go
+++ b/internal/test/complex_recursive.go
@@ -1,0 +1,12 @@
+package test
+
+type ComplexNode struct {
+	Left, Right *ComplexNode
+	Child       *ComplexNodeChild
+}
+
+type ComplexNodeChild struct {
+	Parent   *ComplexNode
+	Child    *ComplexNodeChild
+	Siblings []*ComplexNode
+}

--- a/valast_test.go
+++ b/valast_test.go
@@ -1015,3 +1015,16 @@ func TestAddr_pointer(t *testing.T) {
 		t.Fatal("*got != v")
 	}
 }
+
+func BenchmarkComplexType(b *testing.B) {
+	v := test.ComplexNode{
+		Left: &test.ComplexNode{
+			Child: &test.ComplexNodeChild{
+				Siblings: []*test.ComplexNode{nil, nil, nil},
+			},
+		},
+	}
+	for n := 0; n < b.N; n++ {
+		_ = String(v)
+	}
+}


### PR DESCRIPTION
This benchmark is indicative of the performance issue reported by a user in https://github.com/sourcegraph/sourcegraph/pull/18189

```
$ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/hexops/valast
BenchmarkComplexType-16    	       2	 564812395 ns/op
PASS
ok  	github.com/hexops/valast	9.372s
```

Signed-off-by: Stephen Gutekanst <stephen@hexops.com>