### PR TITLE
bump up gofumpt

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/hexops/autogold v0.8.1
 	github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041
 	golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c
-	mvdan.cc/gofumpt v0.0.0-20210107193838-d24d34e18d44
+	mvdan.cc/gofumpt v0.1.1
 )

--- a/go.sum
+++ b/go.sum
@@ -14,7 +14,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0 h1:8pl+sMODzuvGJkmj2W4kZihvVb5mKm8pB/X44PIQHv8=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
@@ -40,5 +39,5 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
-mvdan.cc/gofumpt v0.0.0-20210107193838-d24d34e18d44 h1:7f9MST3yT/rcobqRRclyjMvnDyjkkjg+EAzBjZ+TLdg=
-mvdan.cc/gofumpt v0.0.0-20210107193838-d24d34e18d44/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
+mvdan.cc/gofumpt v0.1.1 h1:bi/1aS/5W00E2ny5q65w9SnKpWEF/UIOqDYBILpo9rA=
+mvdan.cc/gofumpt v0.1.1/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=


### PR DESCRIPTION
I'm not sure how this happened, but it looks like the current version of gofumpt is available on the default proxy https://proxy.golang.org, but not directly.

You can test this by running the valast tests using the following command:

```
GOMODCACHE=/tmp/gomodcache GOPROXY=direct go test ./...
```

This will setup a local empty cache and directly hit mvdan.cc/gofumpt which I guess will hit github. You should see the following error:

```
go: mvdan.cc/gofumpt@v0.0.0-20210107193838-d24d34e18d44: invalid version: unknown revision d24d34e18d44
```

For this PR, I just bumped gofumpt to v0.1.1 and ran the tests again with the environment variables above. This appears to have fixed the problem!
