### PR TITLE
add Result.Packages for insight into the packages used by the returned AST

### DIFF
--- a/valast.go
+++ b/valast.go
@@ -273,15 +273,12 @@ func AST(v reflect.Value, opt *Options) (Result, error) {
 	r, err := computeASTProfiled(v, opt, &cycleDetector{}, prof, typeExprCache{}, packagesFound)
 	prof.dump()
 
-	packages := make([]string, 0)
 	for k, _ := range packagesFound {
 		if k != "" {
-			packages = append(packages, k)
+			r.Packages = append(r.Packages, k)
 		}
 	}
-	sort.Strings(packages)
-
-	r.Packages = packages
+	sort.Strings(r.Packages)
 
 	return r, err
 }

--- a/valast.go
+++ b/valast.go
@@ -230,6 +230,9 @@ type Result struct {
 	// RequiresUnexported indicates if the AST requires access to unexported types/values outside
 	// of the package specified in the Options, and is thus invalid code.
 	RequiresUnexported bool
+
+	// Packages returns the lsit of packages that are used in the AST.
+	Packages []string
 }
 
 // AST converts the given value into its equivalent Go AST expression.
@@ -261,12 +264,6 @@ type Result struct {
 // 	&foo{id: 123, bar: &foo{id: 123, bar: nil}}
 //
 func AST(v reflect.Value, opt *Options) (Result, error) {
-	r, _, err := ASTWithPackages(v, opt)
-	return r, err
-}
-
-// ASTWithPackages returns the same values of AST and also returns a list of packages required to import.
-func ASTWithPackages(v reflect.Value, opt *Options) (Result, []string, error) {
 	var prof *profiler
 	wantProfile, _ := strconv.ParseBool(os.Getenv("VALAST_PROFILE"))
 	if wantProfile {
@@ -284,7 +281,9 @@ func ASTWithPackages(v reflect.Value, opt *Options) (Result, []string, error) {
 	}
 	sort.Strings(packages)
 
-	return r, packages, err
+	r.Packages = packages
+
+	return r, err
 }
 
 func computeASTProfiled(v reflect.Value, opt *Options, cycleDetector *cycleDetector, profiler *profiler, typeExprCache typeExprCache, packagesFound map[string]bool) (Result, error) {

--- a/valast.go
+++ b/valast.go
@@ -231,7 +231,7 @@ type Result struct {
 	// of the package specified in the Options, and is thus invalid code.
 	RequiresUnexported bool
 
-	// Packages returns the lsit of packages that are used in the AST.
+	// Packages returns the list of packages that are used in the AST.
 	Packages []string
 }
 

--- a/valast.go
+++ b/valast.go
@@ -273,7 +273,7 @@ func AST(v reflect.Value, opt *Options) (Result, error) {
 	r, err := computeASTProfiled(v, opt, &cycleDetector{}, prof, typeExprCache{}, packagesFound)
 	prof.dump()
 
-	for k, _ := range packagesFound {
+	for k := range packagesFound {
 		if k != "" {
 			r.Packages = append(r.Packages, k)
 		}

--- a/valast.go
+++ b/valast.go
@@ -231,7 +231,7 @@ type Result struct {
 	// of the package specified in the Options, and is thus invalid code.
 	RequiresUnexported bool
 
-	// Packages returns the list of packages that are used in the AST.
+	// Packages is the list of packages that are used in the AST.
 	Packages []string
 }
 

--- a/valast_test.go
+++ b/valast_test.go
@@ -1,6 +1,7 @@
 package valast
 
 import (
+	"reflect"
 	"testing"
 	"unsafe"
 
@@ -1013,6 +1014,20 @@ func TestAddr_pointer(t *testing.T) {
 	got := Addr(&x).(**int)
 	if **got != 5 {
 		t.Fatal("*got != v")
+	}
+}
+
+func TestPackages(t *testing.T) {
+	foo := test.NewFoo()
+	res, err := AST(reflect.ValueOf(foo), nil)
+	if err != nil {
+		t.Fatal("error parsing foo for packages", err)
+	}
+	if len(res.Packages) != 1 {
+		t.Fatal("number of expected packages is 1")
+	}
+	if res.Packages[0] != "github.com/hexops/valast/internal/test" {
+		t.Fatal("unexpected package name detected")
 	}
 }
 


### PR DESCRIPTION
In naml, we need to know what packages are included in the AST so that we can handle imports properly.

This patch adds `Result.Packages` which informs the caller of `AST` about which packages the returned AST uses.

Signed-off-by: Frederick F. Kautz IV <fkautz@alumni.cmu.edu>