### PR TITLE
qualify literal values to valast.Addr when required

### DIFF
--- a/testdata/TestIssue15_addr_values_must_be_qualified.golden
+++ b/testdata/TestIssue15_addr_values_must_be_qualified.golden
@@ -1,0 +1,20 @@
+struct {
+	a *float32
+	b *int32
+	c *int64
+	d *uint32
+	e *uint64
+	f *int
+	g *uint
+	h *string
+	i *float64
+}{
+	a: valast.Addr(3607).(*float32), b: valast.Addr(3607).(*int32),
+	c: valast.Addr(3607).(*int64),
+	d: valast.Addr(3607).(*uint32),
+	e: valast.Addr(3607).(*uint64),
+	f: valast.Addr(3607).(*int),
+	g: valast.Addr(3607).(*uint),
+	h: valast.Addr("foobar").(*string),
+	i: valast.Addr(3.14).(*float64),
+}

--- a/testdata/TestIssue15_addr_values_must_be_qualified.golden
+++ b/testdata/TestIssue15_addr_values_must_be_qualified.golden
@@ -9,12 +9,12 @@ struct {
 	h *string
 	i *float64
 }{
-	a: valast.Addr(3607).(*float32), b: valast.Addr(3607).(*int32),
-	c: valast.Addr(3607).(*int64),
-	d: valast.Addr(3607).(*uint32),
-	e: valast.Addr(3607).(*uint64),
+	a: valast.Addr(float32(3607)).(*float32), b: valast.Addr(int32(3607)).(*int32),
+	c: valast.Addr(int64(3607)).(*int64),
+	d: valast.Addr(uint32(3607)).(*uint32),
+	e: valast.Addr(uint64(3607)).(*uint64),
 	f: valast.Addr(3607).(*int),
-	g: valast.Addr(3607).(*uint),
+	g: valast.Addr(uint(3607)).(*uint),
 	h: valast.Addr("foobar").(*string),
 	i: valast.Addr(3.14).(*float64),
 }

--- a/valast_test.go
+++ b/valast_test.go
@@ -1031,6 +1031,32 @@ func TestPackages(t *testing.T) {
 	}
 }
 
+func TestIssue15_addr_values_must_be_qualified(t *testing.T) {
+	f32 := float32(3607)
+	i32 := int32(3607)
+	i64 := int64(3607)
+	u32 := uint32(3607)
+	u64 := uint64(3607)
+	i := int(3607)
+	u := uint(3607)
+	str := "foobar"
+	f64NonInteger := 3.14
+	input := struct {
+		a *float32
+		b *int32
+		c *int64
+		d *uint32
+		e *uint64
+		f *int
+		g *uint
+		h *string
+		i *float64
+	}{&f32, &i32, &i64, &u32, &u64, &i, &u, &str, &f64NonInteger}
+
+	got := String(input)
+	autogold.Equal(t, got)
+}
+
 func BenchmarkComplexType(b *testing.B) {
 	v := test.ComplexNode{
 		Left: &test.ComplexNode{


### PR DESCRIPTION
Fixes #15

First commit adds a test case for various types/values that this could arise for, second commit fixes the issue.