### PR TITLE
customtype: add ability to register any custom type

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This can be useful for debugging and testing, you may think of it as a more comp
 - Fully handles unexported fields, types, and values (optional.)
 - Strong emphasis on being used for producing valid Go code that can be copy & pasted directly into e.g. tests.
 - [Extensively tested](https://github.com/hexops/valast/tree/main/testdata), over 88 tests and handling numerous edge cases (such as pointers to unaddressable literal values like `&"foo"` properly, and even [finding bugs in alternative packages'](https://github.com/shurcooL/go-goon/issues/15)).
+- Provide custom AST representations for your types with `customtypes.Register(...)`.
 
 ## Alternatives comparison
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ This can be useful for debugging and testing, you may think of it as a more comp
 - Fully handles unexported fields, types, and values (optional.)
 - Strong emphasis on being used for producing valid Go code that can be copy & pasted directly into e.g. tests.
 - [Extensively tested](https://github.com/hexops/valast/tree/main/testdata), over 88 tests and handling numerous edge cases (such as pointers to unaddressable literal values like `&"foo"` properly, and even [finding bugs in alternative packages'](https://github.com/shurcooL/go-goon/issues/15)).
-- Provide custom AST representations for your types with `customtypes.Register(...)`.
+- Provide custom AST representations for your types with `valast.RegisterType(...)`.
 
 ## Alternatives comparison
 

--- a/customtype/customtype.go
+++ b/customtype/customtype.go
@@ -1,0 +1,42 @@
+package customtype
+
+import (
+	"fmt"
+	"go/ast"
+	"reflect"
+	"sync"
+)
+
+var (
+	customTypesMux sync.Mutex
+	customTypes    = make(map[reflect.Type]func(any) ast.Expr)
+)
+
+// Register registers a type that for representation in a custom manner with
+// valast. If valast encounters a value or pointer to a value of this type, it
+// will use the given render func to generate the appropriate AST representation.
+//
+// This is useful if a type's fields are private, and can only be represented
+// through a constructor - see stdtypes.go for examples.
+//
+// This mechanism currently only works with struct types.
+func Register[T any](render func(value T) ast.Expr) {
+	customTypesMux.Lock()
+	var zero T
+	t := reflect.TypeOf(zero)
+	if _, exists := customTypes[t]; exists {
+		panic(fmt.Sprintf("%T already registered", zero))
+	}
+	customTypes[t] = func(value any) ast.Expr { return render(value.(T)) }
+	customTypesMux.Unlock()
+}
+
+// Is indicates if the given reflect.Type has a custom AST representation
+// generator registered.
+func Is(rt reflect.Type) (func(any) ast.Expr, bool) {
+	customTypesMux.Lock()
+	defer customTypesMux.Unlock()
+
+	t, ok := customTypes[rt]
+	return t, ok
+}

--- a/internal/customtype/customtype.go
+++ b/internal/customtype/customtype.go
@@ -12,14 +12,7 @@ var (
 	customTypes    = make(map[reflect.Type]func(any) ast.Expr)
 )
 
-// Register registers a type that for representation in a custom manner with
-// valast. If valast encounters a value or pointer to a value of this type, it
-// will use the given render func to generate the appropriate AST representation.
-//
-// This is useful if a type's fields are private, and can only be represented
-// through a constructor - see stdtypes.go for examples.
-//
-// This mechanism currently only works with struct types.
+// See the top-level valast.RegisterType docstring for details.
 func Register[T any](render func(value T) ast.Expr) {
 	customTypesMux.Lock()
 	var zero T

--- a/stdtypes.go
+++ b/stdtypes.go
@@ -5,8 +5,6 @@ import (
 	"go/ast"
 	"go/token"
 	"time"
-
-	"github.com/hexops/valast/customtype"
 )
 
 // Register custom reprsentations of common structs from stdlib that only
@@ -15,7 +13,7 @@ func init() {
 	// For time.Time, returns the AST expression equivalent of:
 	//
 	//	time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-	customtype.Register(func(t time.Time) ast.Expr {
+	RegisterType(func(t time.Time) ast.Expr {
 		return &ast.CallExpr{
 			Fun: &ast.SelectorExpr{
 				X:   &ast.Ident{Name: "time"},

--- a/stdtypes.go
+++ b/stdtypes.go
@@ -1,0 +1,39 @@
+package valast
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+	"time"
+
+	"github.com/hexops/valast/customtype"
+)
+
+// Register custom reprsentations of common structs from stdlib that only
+// contain unexported fields.
+func init() {
+	// For time.Time, returns the AST expression equivalent of:
+	//
+	//	time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
+	customtype.Register(func(t time.Time) ast.Expr {
+		return &ast.CallExpr{
+			Fun: &ast.SelectorExpr{
+				X:   &ast.Ident{Name: "time"},
+				Sel: &ast.Ident{Name: "Date"},
+			},
+			Args: []ast.Expr{
+				&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Year())},
+				&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Month())},
+				&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Day())},
+				&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Hour())},
+				&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Minute())},
+				&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Second())},
+				&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Nanosecond())},
+				&ast.SelectorExpr{
+					X:   &ast.Ident{Name: "time"},
+					Sel: &ast.Ident{Name: t.Location().String()},
+				},
+			},
+		}
+	})
+}

--- a/types.go
+++ b/types.go
@@ -5,7 +5,21 @@ import (
 	"go/ast"
 	"go/token"
 	"reflect"
+
+	"github.com/hexops/valast/internal/customtype"
 )
+
+// RegisterType registers a type that for representation in a custom manner with
+// valast. If valast encounters a value or pointer to a value of this type, it
+// will use the given render func to generate the appropriate AST representation.
+//
+// This is useful if a type's fields are private, and can only be represented
+// through a constructor - see stdtypes.go for examples.
+//
+// This mechanism currently only works with struct types.
+func RegisterType[T any](render func(value T) ast.Expr) {
+	customtype.Register(render)
+}
 
 type cacheKeyOptions struct {
 	Unqualify    bool

--- a/valast.go
+++ b/valast.go
@@ -361,6 +361,12 @@ func computeAST(v reflect.Value, opt *Options, cycleDetector *cycleDetector, pro
 	case reflect.Complex128:
 		return basicLit(vv, token.FLOAT, "complex128", v, opt, typeExprCache)
 	case reflect.Array:
+		if render, ok := customtype.Is(v.Type()); ok {
+			return Result{
+				AST: render(v.Interface()),
+			}, nil
+		}
+
 		var (
 			elts               []ast.Expr
 			requiresUnexported bool

--- a/valast.go
+++ b/valast.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/hexops/valast/customtype"
 	"github.com/hexops/valast/internal/bypass"
+	"github.com/hexops/valast/internal/customtype"
 	"golang.org/x/tools/go/packages"
 	gofumpt "mvdan.cc/gofumpt/format"
 )

--- a/valast.go
+++ b/valast.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/hexops/valast/customtype"
 	"github.com/hexops/valast/internal/bypass"
 	"golang.org/x/tools/go/packages"
 	gofumpt "mvdan.cc/gofumpt/format"
@@ -559,8 +560,8 @@ func computeAST(v reflect.Value, opt *Options, cycleDetector *cycleDetector, pro
 				OmittedUnexported:  elem.OmittedUnexported,
 			}, nil
 		}
-		switch vv.Elem().Type() {
-		case reflect.TypeOf(time.Time{}):
+		// Wrap custom type representations in generic pointer.
+		if _, ok := customtype.Is(vv.Elem().Type()); ok {
 			return Result{
 				AST: pointifyASTExpr(elem.AST),
 			}, nil
@@ -608,12 +609,9 @@ func computeAST(v reflect.Value, opt *Options, cycleDetector *cycleDetector, pro
 		}
 		return basicLit(vv, token.STRING, "string", strconv.Quote(v.String()), opt.withUnqualify(), typeExprCache)
 	case reflect.Struct:
-		// special handling for common structs from stdlib
-		// that only contain unexported fields
-		switch v.Type() {
-		case reflect.TypeOf(time.Time{}):
+		if render, ok := customtype.Is(v.Type()); ok {
 			return Result{
-				AST: timeTypeASTExpr(v.Interface().(time.Time)),
+				AST: render(v.Interface()),
 			}, nil
 		}
 
@@ -719,31 +717,6 @@ func unexported(v reflect.Value) reflect.Value {
 		return v
 	}
 	return bypass.UnsafeReflectValue(v)
-}
-
-// timeTypeASTExpr returns the AST expression equivalent of
-//
-// 	time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
-func timeTypeASTExpr(t time.Time) ast.Expr {
-	return &ast.CallExpr{
-		Fun: &ast.SelectorExpr{
-			X:   &ast.Ident{Name: "time"},
-			Sel: &ast.Ident{Name: "Date"},
-		},
-		Args: []ast.Expr{
-			&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Year())},
-			&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Month())},
-			&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Day())},
-			&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Hour())},
-			&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Minute())},
-			&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Second())},
-			&ast.BasicLit{Kind: token.INT, Value: fmt.Sprintf("%d", t.Nanosecond())},
-			&ast.SelectorExpr{
-				X:   &ast.Ident{Name: "time"},
-				Sel: &ast.Ident{Name: t.Location().String()},
-			},
-		},
-	}
 }
 
 // pointifyASTExpr wraps an expression in a call to the `Ptr` helper function.


### PR DESCRIPTION
This change extends https://github.com/hexops/valast/pull/25 to allow _any_ type to be configured with a custom AST representation, and demonstrates this by migrating the existing `time.Time` handling to use this - see `stdtypes.go` for example. The existing `time.Time` asserts that the functionality remains unchanged.

This is useful for any type in the same situation as `time.Time`, including type aliases of `time.Time`

This could be useful for https://github.com/hexops/valast/issues/21 and https://github.com/hexops/valast/issues/11, allowing users to bring their own representations of types, though it currently does not allow you to override types that are already registered.

- [x] By selecting this checkbox, I agree to license my contributions to this project under the license(s) described in the LICENSE file, and I have the right to do so or have received permission to do so by an employer or client I am producing work for whom has this right.